### PR TITLE
Align name of GSI for JournalPlugin with default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,17 +242,10 @@ Assuming the default values are used (adjust as necessary if not):
 | type | name | partition key | sort key | comments |
 |:----:|:----:|:--------------|:---------|:---------|
 |table | Journal | `pkey` (String) | `sequence-nr` (Number) | Provision capacity as necessary for your application. |
-|index | GetJournalRows (GSI) | `persistence-id` (String) | `sequence-nr` (Number) | Index on the Journal table. |
+|index | GetJournalRowsIndex (GSI) | `persistence-id` (String) | `sequence-nr` (Number) | Index on the Journal table. |
 |table | Snapshots | `persistence-id` (String) | `sequence-nr` (Number) | No indices necessary. |
 
-I also found it necessary to specify the journal index name in the configuration:
 
-```hocon
-j5ik2o.dynamo-db-read-journal {
-  table-name = "Journal"
-  get-journal-rows-index-name = "GetJournalRows"
-}
-```
 As the access to the DynamoDB instance is via the AWS Java SDK, use the methods for the SDK, which are documented at [docs.aws.amazon.com](https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html)
 
 ## License


### PR DESCRIPTION
Align name of GSI for JournalPlugin with default value in JournalPluginConfig in README.md. Another solution could of course be to change the default value in JournalPluginConfig but I figure that might break things for some users