### PR TITLE
Upgrading Akka to version 2.6.3 including fixing deprecation warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ jobs:
           key: scala-library-dependencies-{{ checksum "build.sbt" }}
       - run:
           command: |
-            sbt ++"2.11.12" test
             sbt ++"2.12.10" test
             sbt ++"2.13.1" test
           no_output_timeout: 1h

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-val scala211Version     = "2.11.12"
 val scala212Version     = "2.12.10"
 val scala213Version     = "2.13.1"
 val akkaVersion         = "2.6.3"
@@ -7,10 +6,6 @@ val reactiveAwsDynamoDB = "1.1.6"
 def crossScalacOptions(scalaVersion: String): Seq[String] = CrossVersion.partialVersion(scalaVersion) match {
   case Some((2L, scalaMajor)) if scalaMajor >= 12 =>
     Seq.empty
-  case Some((2L, scalaMajor)) if scalaMajor <= 11 =>
-    Seq(
-      "-Yinline-warnings"
-    )
 }
 
 lazy val deploySettings = Seq(
@@ -53,7 +48,7 @@ lazy val deploySettings = Seq(
 lazy val baseSettings = Seq(
   organization := "com.github.j5ik2o",
   scalaVersion := scala212Version,
-  crossScalaVersions := Seq(scala211Version, scala212Version, scala213Version),
+  crossScalaVersions := Seq(scala212Version, scala213Version),
   scalacOptions ++= (Seq(
       "-feature",
       "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val scala211Version     = "2.11.12"
 val scala212Version     = "2.12.10"
 val scala213Version     = "2.13.1"
-val akkaVersion         = "2.5.29"
+val akkaVersion         = "2.6.3"
 val reactiveAwsDynamoDB = "1.1.6"
 
 def crossScalacOptions(scalaVersion: String): Seq[String] = CrossVersion.partialVersion(scalaVersion) match {

--- a/library/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/library/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -58,7 +58,6 @@ class DynamoDBJournal(config: Config) extends AsyncWriteJournal with ActorLoggin
 
   implicit val ec: ExecutionContext = context.dispatcher
   implicit val system: ActorSystem  = context.system
-  implicit val mat: Materializer    = ActorMaterializer()
   implicit val scheduler: Scheduler = Scheduler(ec)
 
   protected val pluginConfig: JournalPluginConfig = JournalPluginConfig.fromConfig(config)

--- a/library/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/dao/DaoSupport.scala
+++ b/library/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/dao/DaoSupport.scala
@@ -33,7 +33,7 @@ trait DaoSupport {
   )
 
   protected val startTimeSource: Source[Long, NotUsed] = Source
-    .lazily(() => Source.single(System.nanoTime())).mapMaterializedValue(_ => NotUsed)
+    .lazySource(() => Source.single(System.nanoTime())).mapMaterializedValue(_ => NotUsed)
 
   def getMessages(
       persistenceId: PersistenceId,

--- a/library/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/dao/WriteJournalDaoImpl.scala
+++ b/library/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/dao/WriteJournalDaoImpl.scala
@@ -19,9 +19,10 @@ package com.github.j5ik2o.akka.persistence.dynamodb.journal.dao
 import java.io.IOException
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.serialization.Serialization
 import akka.stream.scaladsl.{ Concat, Flow, Keep, Sink, Source, SourceQueueWithComplete }
-import akka.stream.{ Materializer, OverflowStrategy, QueueOfferResult }
+import akka.stream.{ OverflowStrategy, QueueOfferResult }
 import com.github.j5ik2o.akka.persistence.dynamodb.config.{ JournalColumnsDefConfig, JournalPluginConfig }
 import com.github.j5ik2o.akka.persistence.dynamodb.journal.{ JournalRow, PartitionKey, PersistenceId, SequenceNumber }
 import com.github.j5ik2o.akka.persistence.dynamodb.metrics.MetricsReporter
@@ -44,7 +45,7 @@ class WriteJournalDaoImpl(
     protected val metricsReporter: MetricsReporter
 )(
     implicit ec: ExecutionContext,
-    mat: Materializer
+    system: ActorSystem
 ) extends WriteJournalDao
     with DaoSupport {
 
@@ -675,7 +676,7 @@ class WriteJournalDaoImpl(
               Source.single(0L)
             else
               Source
-                .lazily { () =>
+                .lazySource { () =>
                   val requestItems = persistenceIdWithSeqNrs.map { persistenceIdWithSeqNr =>
                     WriteRequest
                       .builder().deleteRequest(
@@ -804,7 +805,7 @@ class WriteJournalDaoImpl(
             Source.single(0L)
           else
             Source
-              .lazily { () =>
+              .lazySource { () =>
                 val requestItems = journalRows.map { journalRow =>
                   WriteRequest
                     .builder().putRequest(

--- a/library/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStore.scala
+++ b/library/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStore.scala
@@ -44,7 +44,6 @@ class DynamoDBSnapshotStore(config: Config) extends SnapshotStore {
 
   implicit val ec: ExecutionContext = context.dispatcher
   implicit val system: ActorSystem  = context.system
-  implicit val mat: Materializer    = ActorMaterializer()
 
   private val serialization                        = SerializationExtension(system)
   protected val pluginConfig: SnapshotPluginConfig = SnapshotPluginConfig.fromConfig(config)

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/WriteJournalDaoImplSpec.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/WriteJournalDaoImplSpec.scala
@@ -18,7 +18,8 @@ import com.github.j5ik2o.reactive.aws.dynamodb.{ DynamoDbAsyncClient, DynamoDbSy
 import com.typesafe.config.ConfigFactory
 import monix.execution.Scheduler
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ FreeSpecLike, Matchers }
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
 import software.amazon.awssdk.services.dynamodb.{
   DynamoDbAsyncClient => JavaDynamoDbAsyncClient,
@@ -29,7 +30,7 @@ import scala.concurrent.duration._
 
 class WriteJournalDaoImplSpec
     extends TestKit(ActorSystem("ReadJournalDaoImplSpec", ConfigFactory.load()))
-    with FreeSpecLike
+    with AnyFreeSpecLike
     with Matchers
     with ScalaFutures
     with DynamoDBSpecSupport {
@@ -66,14 +67,13 @@ class WriteJournalDaoImplSpec
   private val queryPluginConfig: QueryPluginConfig =
     QueryPluginConfig.fromConfig(system.settings.config.asConfig("dynamo-db-read-journal"))
 
-  implicit val mat = ActorMaterializer()
-  implicit val ec  = system.dispatcher
+  implicit val ec = system.dispatcher
 
   val readJournalDao =
     new ReadJournalDaoImpl(asyncClient, serialization, queryPluginConfig, new NullMetricsReporter)(ec)
 
   val writeJournalDao =
-    new WriteJournalDaoImpl(asyncClient, serialization, journalPluginConfig, new NullMetricsReporter)(ec, mat)
+    new WriteJournalDaoImpl(asyncClient, serialization, journalPluginConfig, new NullMetricsReporter)(ec, system)
 
   val sch = Scheduler(ec)
 

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/QueryJournalSpec.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/QueryJournalSpec.scala
@@ -32,7 +32,9 @@ import akka.util.Timeout
 import com.github.j5ik2o.akka.persistence.dynamodb.query.scaladsl.DynamoDBReadJournal
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers }
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
@@ -40,14 +42,13 @@ import scala.language.implicitConversions
 import scala.util.Try
 
 abstract class QueryJournalSpec(config: Config)
-    extends FlatSpec
+    extends AnyFlatSpecLike
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with Eventually {
   implicit val system: ActorSystem  = ActorSystem("test", config)
-  implicit val mat: Materializer    = ActorMaterializer()
   implicit val ec: ExecutionContext = system.dispatcher
   val log: LoggingAdapter           = Logging(system, this.getClass)
   implicit val pc: PatienceConfig   = PatienceConfig(timeout = 2.seconds)

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/dao/ReadJournalDaoImplSpec.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/dao/ReadJournalDaoImplSpec.scala
@@ -33,7 +33,8 @@ import com.github.j5ik2o.reactive.aws.dynamodb.monix.DynamoDbMonixClient
 import com.typesafe.config.ConfigFactory
 import monix.execution.Scheduler
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ FreeSpecLike, Matchers }
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
 import software.amazon.awssdk.services.dynamodb.{ DynamoDbAsyncClient => JavaDynamoDbAsyncClient }
 
@@ -41,7 +42,7 @@ import scala.concurrent.duration._
 
 class ReadJournalDaoImplSpec
     extends TestKit(ActorSystem("ReadJournalDaoImplSpec", ConfigFactory.load()))
-    with FreeSpecLike
+    with AnyFreeSpecLike
     with Matchers
     with ScalaFutures
     with DynamoDBSpecSupport {
@@ -70,14 +71,13 @@ class ReadJournalDaoImplSpec
   private val queryPluginConfig: QueryPluginConfig =
     QueryPluginConfig.fromConfig(system.settings.config.asConfig("dynamo-db-read-journal"))
 
-  implicit val mat = ActorMaterializer()
-  implicit val ec  = system.dispatcher
+  implicit val ec = system.dispatcher
 
   val readJournalDao =
     new ReadJournalDaoImpl(asyncClient, serialization, queryPluginConfig, new NullMetricsReporter)(ec)
 
   val writeJournalDao =
-    new WriteJournalDaoImpl(asyncClient, serialization, journalPluginConfig, new NullMetricsReporter)(ec, mat)
+    new WriteJournalDaoImpl(asyncClient, serialization, journalPluginConfig, new NullMetricsReporter)(ec, system)
 
   val sch = Scheduler(ec)
 

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByPersistenceId1Test.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByPersistenceId1Test.scala
@@ -43,55 +43,55 @@ abstract class CurrentEventsByPersistenceId1Test(config: Config) extends QueryJo
 
     withCurrentEventsByPersistenceId()("my-1", 0, 1) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 1, 2) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 0, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 1, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
   }

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByPersistenceId2Test.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByPersistenceId2Test.scala
@@ -46,47 +46,47 @@ abstract class CurrentEventsByPersistenceId2Test(config: Config) extends QueryJo
 
       withCurrentEventsByPersistenceId()("my-1", 0, 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
+        tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
+        tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 1, 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
+        tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+        tp.expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", -1, 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
+        tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+        tp.expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        tp.expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        tp.expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 6, 7) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(6), "my-1", 6, "a-6"))
-        tp.expectNext(EventEnvelope(Sequence(7), "my-1", 7, "a-7"))
+        tp.expectNext(new EventEnvelope(Sequence(6), "my-1", 6, "a-6", 0L))
+        tp.expectNext(new EventEnvelope(Sequence(7), "my-1", 7, "a-7", 0L))
         tp.expectComplete()
       }
 
       withCurrentEventsByPersistenceId()("my-1", 7, 7) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(7), "my-1", 7, "a-7"))
+        tp.expectNext(new EventEnvelope(Sequence(7), "my-1", 7, "a-7", 0L))
         tp.expectComplete()
       }
 

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByPersistenceIdDeleteEventsTest.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByPersistenceIdDeleteEventsTest.scala
@@ -43,9 +43,9 @@ abstract class CurrentEventsByPersistenceIdDeleteEventsTest(config: Config) exte
 
       withCurrentEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "b-2"))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+          .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "b-2", 0L))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 
@@ -53,8 +53,8 @@ abstract class CurrentEventsByPersistenceIdDeleteEventsTest(config: Config) exte
 
       withCurrentEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "b-2"))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "b-2", 0L))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 
@@ -62,7 +62,7 @@ abstract class CurrentEventsByPersistenceIdDeleteEventsTest(config: Config) exte
 
       withCurrentEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByPersistenceIdMultipleActorsDeleteEventsTest.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByPersistenceIdMultipleActorsDeleteEventsTest.scala
@@ -44,9 +44,9 @@ abstract class CurrentEventsByPersistenceIdMultipleActorsDeleteEventsTest(config
 
       withCurrentEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "b-2"))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+          .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "b-2", 0L))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 
@@ -54,8 +54,8 @@ abstract class CurrentEventsByPersistenceIdMultipleActorsDeleteEventsTest(config
 
       withCurrentEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "b-2"))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "b-2", 0L))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 
@@ -63,7 +63,7 @@ abstract class CurrentEventsByPersistenceIdMultipleActorsDeleteEventsTest(config
 
       withCurrentEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByTagTest5.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByTagTest5.scala
@@ -52,7 +52,7 @@ abstract class CurrentEventsByTagTest5(config: Config) extends QueryJournalSpec(
 
     withCurrentEventsByTag()("one", NoOffset) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
       tp.expectComplete()
     }
     withCurrentEventsByTag()("one", Sequence(1)) { tp =>
@@ -62,63 +62,63 @@ abstract class CurrentEventsByTagTest5(config: Config) extends QueryJournalSpec(
 
     withCurrentEventsByTag()("prime", NoOffset) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-      tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
-      tp.expectNext(EventEnvelope(Sequence(4), "my-1", 5, "a-5"))
-      tp.expectNext(EventEnvelope(Sequence(5), "my-2", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(6), "my-3", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(4), "my-1", 5, "a-5", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(5), "my-2", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(6), "my-3", 1, "a-1", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("prime", Sequence(0)) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-      tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
-      tp.expectNext(EventEnvelope(Sequence(4), "my-1", 5, "a-5"))
-      tp.expectNext(EventEnvelope(Sequence(5), "my-2", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(6), "my-3", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(4), "my-1", 5, "a-5", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(5), "my-2", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(6), "my-3", 1, "a-1", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("prime", Sequence(1)) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-      tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
-      tp.expectNext(EventEnvelope(Sequence(4), "my-1", 5, "a-5"))
-      tp.expectNext(EventEnvelope(Sequence(5), "my-2", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(6), "my-3", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(4), "my-1", 5, "a-5", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(5), "my-2", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(6), "my-3", 1, "a-1", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("prime", Sequence(2)) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
-      tp.expectNext(EventEnvelope(Sequence(4), "my-1", 5, "a-5"))
-      tp.expectNext(EventEnvelope(Sequence(5), "my-2", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(6), "my-3", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(4), "my-1", 5, "a-5", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(5), "my-2", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(6), "my-3", 1, "a-1", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("prime", Sequence(3)) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(4), "my-1", 5, "a-5"))
-      tp.expectNext(EventEnvelope(Sequence(5), "my-2", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(6), "my-3", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(4), "my-1", 5, "a-5", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(5), "my-2", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(6), "my-3", 1, "a-1", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("prime", Sequence(4)) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(5), "my-2", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(6), "my-3", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(5), "my-2", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(6), "my-3", 1, "a-1", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("prime", Sequence(5)) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(6), "my-3", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(6), "my-3", 1, "a-1", 0L))
       tp.expectComplete()
     }
 
@@ -134,33 +134,33 @@ abstract class CurrentEventsByTagTest5(config: Config) extends QueryJournalSpec(
 
     withCurrentEventsByTag()("3", NoOffset) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(1), "my-1", 3, "a-3"))
-      tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, "a-1"))
-      tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, "a-1"))
+      tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 3, "a-3", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(2), "my-2", 1, "a-1", 0L))
+      tp.expectNext(new EventEnvelope(Sequence(3), "my-3", 1, "a-1", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("4", NoOffset) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(1), "my-1", 4, "a-4"))
+      tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 4, "a-4", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("four", NoOffset) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(1), "my-1", 4, "a-4"))
+      tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 4, "a-4", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("5", NoOffset) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(1), "my-1", 5, "a-5"))
+      tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 5, "a-5", 0L))
       tp.expectComplete()
     }
 
     withCurrentEventsByTag()("five", NoOffset) { tp =>
       tp.request(Int.MaxValue)
-      tp.expectNext(EventEnvelope(Sequence(1), "my-1", 5, "a-5"))
+      tp.expectNext(new EventEnvelope(Sequence(1), "my-1", 5, "a-5", 0L))
       tp.expectComplete()
     }
   }

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByTagTestDeletedEventsTest.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentEventsByTagTestDeletedEventsTest.scala
@@ -40,9 +40,9 @@ abstract class CurrentEventsByTagTestDeletedEventsTest(config: Config) extends Q
 
       withCurrentEventsByTag()("one", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "b-2"))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+          .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "b-2", 0L))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 
@@ -50,9 +50,9 @@ abstract class CurrentEventsByTagTestDeletedEventsTest(config: Config) extends Q
 
       withCurrentEventsByTag()("one", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "b-2"))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+          .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "b-2", 0L))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 
@@ -60,9 +60,9 @@ abstract class CurrentEventsByTagTestDeletedEventsTest(config: Config) extends Q
 
       withCurrentEventsByTag()("one", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "b-2"))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+          .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "b-2", 0L))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
 
@@ -70,9 +70,9 @@ abstract class CurrentEventsByTagTestDeletedEventsTest(config: Config) extends Q
 
       withCurrentEventsByTag()("one", 0) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "b-2"))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "c-3"))
+          .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+          .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "b-2", 0L))
+          .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "c-3", 0L))
           .expectComplete()
       }
     }

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentPersistenceIds1Test.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentPersistenceIds1Test.scala
@@ -45,8 +45,8 @@ abstract class CurrentPersistenceIds1Test(config: Config) extends QueryJournalSp
 
       withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        tp.expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        tp.expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         tp.expectComplete()
       }
     }

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentPersistenceIds2Test.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/CurrentPersistenceIds2Test.scala
@@ -39,26 +39,26 @@ abstract class CurrentPersistenceIds2Test(config: Config) extends QueryJournalSp
 
     withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
 
     withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
   }

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/EventsByPersistenceIdTest.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/query/EventsByPersistenceIdTest.scala
@@ -60,55 +60,55 @@ abstract class EventsByPersistenceIdTest(config: Config) extends QueryJournalSpe
 
     withEventsByPersistenceId()("my-1", 0, 1) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
         .expectComplete()
     }
 
     withEventsByPersistenceId()("my-1", 1, 1) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
         .expectComplete()
     }
 
     withEventsByPersistenceId()("my-1", 1, 2) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
         .expectComplete()
     }
 
     withEventsByPersistenceId()("my-1", 2, 2) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
         .expectComplete()
     }
 
     withEventsByPersistenceId()("my-1", 2, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
 
     withEventsByPersistenceId()("my-1", 3, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
 
     withEventsByPersistenceId()("my-1", 0, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
 
     withEventsByPersistenceId()("my-1", 1, 3) { tp =>
       tp.request(Int.MaxValue)
-        .expectNext(EventEnvelope(Sequence(1), "my-1", 1, "a-1"))
-        .expectNext(EventEnvelope(Sequence(2), "my-1", 2, "a-2"))
-        .expectNext(EventEnvelope(Sequence(3), "my-1", 3, "a-3"))
+        .expectNext(new EventEnvelope(Sequence(1), "my-1", 1, "a-1", 0L))
+        .expectNext(new EventEnvelope(Sequence(2), "my-1", 2, "a-2", 0L))
+        .expectNext(new EventEnvelope(Sequence(3), "my-1", 3, "a-3", 0L))
         .expectComplete()
     }
   }

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/scaladsl/DynamoDBReadJournalSpec.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/query/scaladsl/DynamoDBReadJournalSpec.scala
@@ -39,7 +39,10 @@ import com.github.j5ik2o.reactive.aws.dynamodb.akka.DynamoDbAkkaClient
 import com.github.j5ik2o.reactive.aws.dynamodb.monix.DynamoDbMonixClient
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
-import org.scalatest.{ BeforeAndAfter, FreeSpecLike, Matchers }
+import org.scalatest.{ BeforeAndAfter, Matchers }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.freespec.AnyFreeSpecLike
+
 import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.services.dynamodb.{ DynamoDbAsyncClient => JavaDynamoDbAsyncClient }
@@ -73,7 +76,7 @@ class DynamoDBReadJournalSpec
           ).withFallback(ConfigFactory.load())
       )
     )
-    with FreeSpecLike
+    with AnyFreeSpecLike
     with Matchers
     with Eventually
     with ScalaFutures
@@ -93,8 +96,7 @@ class DynamoDBReadJournalSpec
     .endpointOverride(URI.create(dynamoDBEndpoint))
     .build()
 
-  implicit val mat = ActorMaterializer()
-  implicit val ec  = system.dispatcher
+  implicit val ec = system.dispatcher
 
   private val config = system.settings.config
 
@@ -114,7 +116,7 @@ class DynamoDBReadJournalSpec
     new ReadJournalDaoImpl(asyncClient, serialization, queryPluginConfig, new NullMetricsReporter)(ec)
 
   val writeJournalDao =
-    new WriteJournalDaoImpl(asyncClient, serialization, journalPluginConfig, new NullMetricsReporter)(ec, mat)
+    new WriteJournalDaoImpl(asyncClient, serialization, journalPluginConfig, new NullMetricsReporter)(ec, system)
 
   val readJournal: ReadJournal
     with CurrentPersistenceIdsQuery

--- a/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/utils/DynamoDBSpecSupport.scala
+++ b/library/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/utils/DynamoDBSpecSupport.scala
@@ -3,7 +3,8 @@ package com.github.j5ik2o.akka.persistence.dynamodb.utils
 import com.github.j5ik2o.reactive.aws.dynamodb.implicits._
 import com.github.j5ik2o.reactive.aws.dynamodb.{ DynamoDBEmbeddedSpecSupport, DynamoDbAsyncClient }
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
-import org.scalatest.{ BeforeAndAfter, Matchers, Suite }
+import org.scalatest.{ BeforeAndAfter, Suite }
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.bridge.SLF4JBridgeHandler
 import org.slf4j.{ Logger, LoggerFactory }
 import software.amazon.awssdk.services.dynamodb.model._

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.19"
+version in ThisBuild := "1.0.20-SNAPSHOT"


### PR DESCRIPTION
- Upgrading to Akka 2.6.3
- Fixing deprecation warnings including
-- Removing references to ActorMaterializer
-- Changing ScalaTest imports to use new packages/classes from 3.1.0
-- Change test to use non-deprecated constructor for EventSource
-- Use lazySource instead of deprecated lazily factory method for Source