### PR TITLE
fixes the config path for persistance id separator in SortKeyResolver

### DIFF
--- a/journal/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/SortKeyResolver.scala
+++ b/journal/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/journal/SortKeyResolver.scala
@@ -83,7 +83,7 @@ object SortKeyResolver {
       with ToPersistenceIdOps {
 
     override def separator: String =
-      journalPluginConfig.sourceConfig.getOrElse[String]("separator", PersistenceId.Separator)
+      journalPluginConfig.sourceConfig.getOrElse[String]("persistence-id-separator", PersistenceId.Separator)
 
     // ${persistenceId.body}-${sequenceNumber}
     override def resolve(persistenceId: PersistenceId, sequenceNumber: SequenceNumber): SortKey = {


### PR DESCRIPTION
Seems there's glitch in `SortKeyResolver` where config path for `PersistenceId` separator is wrong/not aligned with the documentation/ different than `PartitionKeyResolver`. This tripped me over when trying to change the default separator from `-` to `#`