### PR TITLE
Fixed some nits

### DIFF
--- a/base/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/metrics/MetricsReporter.scala
+++ b/base/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/metrics/MetricsReporter.scala
@@ -5,6 +5,7 @@ import com.github.j5ik2o.akka.persistence.dynamodb.config.PluginConfig
 import com.github.j5ik2o.akka.persistence.dynamodb.exception.PluginException
 import com.github.j5ik2o.akka.persistence.dynamodb.model.Context
 
+import scala.annotation.unused
 import scala.collection.immutable._
 import scala.util.{ Failure, Success }
 
@@ -13,109 +14,61 @@ import scala.util.{ Failure, Success }
 abstract class MetricsReporter(val pluginConfig: PluginConfig) {
 
   def beforeJournalAsyncWriteMessages(context: Context): Context = { context }
-  def afterJournalAsyncWriteMessages(context: Context): Unit = {}
-  def errorJournalAsyncWriteMessages(context: Context, ex: Throwable): Unit = {}
+  def afterJournalAsyncWriteMessages(@unused context: Context): Unit = {}
+  def errorJournalAsyncWriteMessages(@unused context: Context, @unused ex: Throwable): Unit = {}
 
-  def beforeJournalAsyncDeleteMessagesTo(context: Context): Context = { context }
-  def afterJournalAsyncDeleteMessagesTo(context: Context): Unit = {}
-  def errorJournalAsyncDeleteMessagesTo(context: Context, ex: Throwable): Unit = {}
+  def beforeJournalAsyncDeleteMessagesTo(@unused context: Context): Context = { context }
+  def afterJournalAsyncDeleteMessagesTo(@unused context: Context): Unit = {}
+  def errorJournalAsyncDeleteMessagesTo(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeJournalAsyncReplayMessages(context: Context): Context = { context }
-  def afterJournalAsyncReplayMessages(context: Context): Unit = {}
-  def errorJournalAsyncReplayMessages(context: Context, ex: Throwable): Unit = {}
+  def afterJournalAsyncReplayMessages(@unused context: Context): Unit = {}
+  def errorJournalAsyncReplayMessages(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeJournalAsyncReadHighestSequenceNr(context: Context): Context = { context }
-  def afterJournalAsyncReadHighestSequenceNr(context: Context): Unit = {}
-  def errorJournalAsyncReadHighestSequenceNr(context: Context, ex: Throwable): Unit = {}
+  def afterJournalAsyncReadHighestSequenceNr(@unused context: Context): Unit = {}
+  def errorJournalAsyncReadHighestSequenceNr(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeJournalAsyncUpdateEvent(context: Context): Context = { context }
-  def afterJournalAsyncUpdateEvent(context: Context): Unit = {}
-  def errorJournalAsyncUpdateEvent(context: Context, ex: Throwable): Unit = {}
+  def afterJournalAsyncUpdateEvent(@unused context: Context): Unit = {}
+  def errorJournalAsyncUpdateEvent(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeJournalSerializeJournal(context: Context): Context = { context }
-  def afterJournalSerializeJournal(context: Context): Unit = {}
-  def errorJournalSerializeJournal(context: Context, ex: Throwable): Unit = {}
+  def afterJournalSerializeJournal(@unused context: Context): Unit = {}
+  def errorJournalSerializeJournal(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeJournalDeserializeJournal(context: Context): Context = { context }
-  def afterJournalDeserializeJournal(context: Context): Unit = {}
-  def errorJournalDeserializeJournal(context: Context, ex: Throwable): Unit = {}
+  def afterJournalDeserializeJournal(@unused context: Context): Unit = {}
+  def errorJournalDeserializeJournal(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeSnapshotStoreLoadAsync(context: Context): Context = { context }
-  def afterSnapshotStoreLoadAsync(context: Context): Unit = {}
-  def errorSnapshotStoreLoadAsync(context: Context, ex: Throwable): Unit = {}
+  def afterSnapshotStoreLoadAsync(@unused context: Context): Unit = {}
+  def errorSnapshotStoreLoadAsync(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeSnapshotStoreSaveAsync(context: Context): Context = { context }
-  def afterSnapshotStoreSaveAsync(context: Context): Unit = {}
-  def errorSnapshotStoreSaveAsync(context: Context, ex: Throwable): Unit = {}
+  def afterSnapshotStoreSaveAsync(@unused context: Context): Unit = {}
+  def errorSnapshotStoreSaveAsync(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeSnapshotStoreDeleteAsync(context: Context): Context = { context }
-  def afterSnapshotStoreDeleteAsync(context: Context): Unit = {}
-  def errorSnapshotStoreDeleteAsync(context: Context, ex: Throwable): Unit = {}
+  def afterSnapshotStoreDeleteAsync(@unused context: Context): Unit = {}
+  def errorSnapshotStoreDeleteAsync(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeSnapshotStoreDeleteWithCriteriaAsync(context: Context): Context = { context }
-  def afterSnapshotStoreDeleteWithCriteriaAsync(context: Context): Unit = {}
-  def errorSnapshotStoreDeleteWithCriteriaAsync(context: Context, ex: Throwable): Unit = {}
+  def afterSnapshotStoreDeleteWithCriteriaAsync(@unused context: Context): Unit = {}
+  def errorSnapshotStoreDeleteWithCriteriaAsync(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeSnapshotStoreSerializeSnapshot(context: Context): Context = { context }
-  def afterSnapshotStoreSerializeSnapshot(context: Context): Unit = {}
-  def errorSnapshotStoreSerializeSnapshot(context: Context, ex: Throwable): Unit = {}
+  def afterSnapshotStoreSerializeSnapshot(@unused context: Context): Unit = {}
+  def errorSnapshotStoreSerializeSnapshot(@unused context: Context, @unused ex: Throwable): Unit = {}
 
   def beforeSnapshotStoreDeserializeSnapshot(context: Context): Context = { context }
-  def afterSnapshotStoreDeserializeSnapshot(context: Context): Unit = {}
-  def errorSnapshotStoreDeserializeSnapshot(context: Context, ex: Throwable): Unit = {}
+  def afterSnapshotStoreDeserializeSnapshot(@unused context: Context): Unit = {}
+  def errorSnapshotStoreDeserializeSnapshot(@unused context: Context, @unused ex: Throwable): Unit = {}
 }
 
 object MetricsReporter {
 
-  class None(pluginConfig: PluginConfig) extends MetricsReporter(pluginConfig) {
-    override def beforeJournalAsyncWriteMessages(context: Context): Context = { context }
-    override def afterJournalAsyncWriteMessages(context: Context): Unit = {}
-    override def errorJournalAsyncWriteMessages(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeJournalAsyncDeleteMessagesTo(context: Context): Context = { context }
-    override def afterJournalAsyncDeleteMessagesTo(context: Context): Unit = {}
-    override def errorJournalAsyncDeleteMessagesTo(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeJournalAsyncReplayMessages(context: Context): Context = { context }
-    override def afterJournalAsyncReplayMessages(context: Context): Unit = {}
-    override def errorJournalAsyncReplayMessages(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeJournalAsyncReadHighestSequenceNr(context: Context): Context = { context }
-    override def afterJournalAsyncReadHighestSequenceNr(context: Context): Unit = {}
-    override def errorJournalAsyncReadHighestSequenceNr(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeJournalAsyncUpdateEvent(context: Context): Context = { context }
-    override def afterJournalAsyncUpdateEvent(context: Context): Unit = {}
-    override def errorJournalAsyncUpdateEvent(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeJournalSerializeJournal(context: Context): Context = { context }
-    override def afterJournalSerializeJournal(context: Context): Unit = {}
-    override def errorJournalSerializeJournal(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeJournalDeserializeJournal(context: Context): Context = { context }
-    override def afterJournalDeserializeJournal(context: Context): Unit = {}
-    override def errorJournalDeserializeJournal(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeSnapshotStoreLoadAsync(context: Context): Context = { context }
-    override def afterSnapshotStoreLoadAsync(context: Context): Unit = {}
-    override def errorSnapshotStoreLoadAsync(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeSnapshotStoreSaveAsync(context: Context): Context = { context }
-    override def afterSnapshotStoreSaveAsync(context: Context): Unit = {}
-    override def errorSnapshotStoreSaveAsync(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeSnapshotStoreDeleteAsync(context: Context): Context = { context }
-    override def afterSnapshotStoreDeleteAsync(context: Context): Unit = {}
-    override def errorSnapshotStoreDeleteAsync(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeSnapshotStoreSerializeSnapshot(context: Context): Context = { context }
-    override def afterSnapshotStoreSerializeSnapshot(context: Context): Unit = {}
-    override def errorSnapshotStoreSerializeSnapshot(context: Context, ex: Throwable): Unit = {}
-
-    override def beforeSnapshotStoreDeserializeSnapshot(context: Context): Context = { context }
-    override def afterSnapshotStoreDeserializeSnapshot(context: Context): Unit = {}
-    override def errorSnapshotStoreDeserializeSnapshot(context: Context, ex: Throwable): Unit = {}
-  }
+  final class None(pluginConfig: PluginConfig) extends MetricsReporter(pluginConfig)
 
 }
 

--- a/base/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/metrics/MetricsReporter.scala
+++ b/base/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/metrics/MetricsReporter.scala
@@ -10,7 +10,7 @@ import scala.util.{ Failure, Success }
 
 /** MetricsReporter.
   */
-trait MetricsReporter {
+abstract class MetricsReporter(val pluginConfig: PluginConfig) {
 
   def beforeJournalAsyncWriteMessages(context: Context): Context = { context }
   def afterJournalAsyncWriteMessages(context: Context): Unit = {}
@@ -67,7 +67,7 @@ trait MetricsReporter {
 
 object MetricsReporter {
 
-  class None(pluginConfig: PluginConfig) extends MetricsReporter {
+  class None(pluginConfig: PluginConfig) extends MetricsReporter(pluginConfig) {
     override def beforeJournalAsyncWriteMessages(context: Context): Context = { context }
     override def afterJournalAsyncWriteMessages(context: Context): Unit = {}
     override def errorJournalAsyncWriteMessages(context: Context, ex: Throwable): Unit = {}

--- a/base/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/trace/TraceReporter.scala
+++ b/base/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/trace/TraceReporter.scala
@@ -12,7 +12,7 @@ import scala.util.{ Failure, Success }
 
 /** TraceReporter.
   */
-trait TraceReporter {
+abstract class TraceReporter(val pluginConfig: PluginConfig) {
 
   def traceJournalAsyncWriteMessages[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
@@ -44,7 +44,7 @@ trait TraceReporter {
 
 object TraceReporter {
 
-  final class None(@unused pluginConfig: PluginConfig) extends TraceReporter
+  final class None(pluginConfig: PluginConfig) extends TraceReporter(pluginConfig)
 
 }
 

--- a/base/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/trace/TraceReporter.scala
+++ b/base/src/main/scala/com/github/j5ik2o/akka/persistence/dynamodb/trace/TraceReporter.scala
@@ -5,6 +5,7 @@ import com.github.j5ik2o.akka.persistence.dynamodb.config.PluginConfig
 import com.github.j5ik2o.akka.persistence.dynamodb.exception.PluginException
 import com.github.j5ik2o.akka.persistence.dynamodb.model.Context
 
+import scala.annotation.unused
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.util.{ Failure, Success }
@@ -13,64 +14,37 @@ import scala.util.{ Failure, Success }
   */
 trait TraceReporter {
 
-  def traceJournalAsyncWriteMessages[T](context: Context)(f: => Future[T]): Future[T]
+  def traceJournalAsyncWriteMessages[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceJournalAsyncDeleteMessagesTo[T](context: Context)(f: => Future[T]): Future[T]
+  def traceJournalAsyncDeleteMessagesTo[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceJournalAsyncReplayMessages[T](context: Context)(f: => Future[T]): Future[T]
+  def traceJournalAsyncReplayMessages[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceJournalAsyncReadHighestSequenceNr[T](context: Context)(f: => Future[T]): Future[T]
+  def traceJournalAsyncReadHighestSequenceNr[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceJournalAsyncUpdateEvent[T](context: Context)(f: => Future[T]): Future[T]
+  def traceJournalAsyncUpdateEvent[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceJournalSerializeJournal[T](context: Context)(f: => Future[T]): Future[T]
+  def traceJournalSerializeJournal[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceJournalDeserializeJournal[T](context: Context)(f: => Future[T]): Future[T]
+  def traceJournalDeserializeJournal[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceSnapshotStoreLoadAsync[T](context: Context)(f: => Future[T]): Future[T]
+  def traceSnapshotStoreLoadAsync[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceSnapshotStoreSaveAsync[T](context: Context)(f: => Future[T]): Future[T]
+  def traceSnapshotStoreSaveAsync[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceSnapshotStoreDeleteAsync[T](context: Context)(f: => Future[T]): Future[T]
+  def traceSnapshotStoreDeleteAsync[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceSnapshotStoreDeleteWithCriteriaAsync[T](context: Context)(f: => Future[T]): Future[T]
+  def traceSnapshotStoreDeleteWithCriteriaAsync[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceSnapshotStoreSerializeSnapshot[T](context: Context)(f: => Future[T]): Future[T]
+  def traceSnapshotStoreSerializeSnapshot[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
-  def traceSnapshotStoreDeserializeSnapshot[T](context: Context)(f: => Future[T]): Future[T]
+  def traceSnapshotStoreDeserializeSnapshot[T](@unused context: Context)(f: => Future[T]): Future[T] = f
 
 }
 
 object TraceReporter {
 
-  class None(pluginConfig: PluginConfig) extends TraceReporter {
-    def traceJournalAsyncWriteMessages[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceJournalAsyncDeleteMessagesTo[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceJournalAsyncReplayMessages[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceJournalAsyncReadHighestSequenceNr[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceJournalAsyncUpdateEvent[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceJournalSerializeJournal[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceJournalDeserializeJournal[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceSnapshotStoreLoadAsync[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceSnapshotStoreSaveAsync[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceSnapshotStoreDeleteAsync[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceSnapshotStoreDeleteWithCriteriaAsync[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceSnapshotStoreSerializeSnapshot[T](context: Context)(f: => Future[T]): Future[T] = f
-
-    def traceSnapshotStoreDeserializeSnapshot[T](context: Context)(f: => Future[T]): Future[T] = f
-
-  }
+  final class None(@unused pluginConfig: PluginConfig) extends TraceReporter
 
 }
 

--- a/journal/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/config/LegacyConfigFormatSpec.scala
+++ b/journal/src/test/scala/com/github/j5ik2o/akka/persistence/dynamodb/config/LegacyConfigFormatSpec.scala
@@ -15,7 +15,7 @@ class PartitionKeyResolverImpl(config: Config) extends PartitionKeyResolver {
 
 }
 
-class MetricsReporterImpl extends MetricsReporter
+class MetricsReporterImpl(pluginConfig: PluginConfig) extends MetricsReporter(pluginConfig)
 
 class LegacyConfigFormatSpec extends AnyFreeSpec with Matchers {
   "config" - {


### PR DESCRIPTION
- Implemented to simply execute f in all methods of TraceReporter so that the user does not have to implement all methods of TraceReporter.
- MetricsReporter/TraceReporter was changed from a trait to an abstruct class so that the implementation class of MetricsReporter/TraceReporter needs to take PluginConfig in its constructor for convenience of initialization process.
- Remove unnecessary override method in MetricsReporter#None.